### PR TITLE
Use PhpParser\NodeVisitor\ParentConnectingVisitor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.1-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3 || ^8.0",
-        "nikic/php-parser": "^4.6"
+        "nikic/php-parser": "^4.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.2"

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -13,6 +13,7 @@ use PhpParser\Error;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor as PhpParserParentConnectingVisitor;
 use PhpParser\ParserFactory;
 
 final class Calculator
@@ -61,7 +62,7 @@ final class Calculator
         $complexityCalculatingVisitor = new ComplexityCalculatingVisitor(true);
 
         $traverser->addVisitor(new NameResolver);
-        $traverser->addVisitor(new ParentConnectingVisitor);
+        $traverser->addVisitor(new PhpParserParentConnectingVisitor);
         $traverser->addVisitor($complexityCalculatingVisitor);
 
         try {

--- a/src/Visitor/ParentConnectingVisitor.php
+++ b/src/Visitor/ParentConnectingVisitor.php
@@ -16,6 +16,7 @@ use PhpParser\NodeVisitorAbstract;
 
 /**
  * @see https://github.com/nikic/PHP-Parser/blob/v4.6.0/doc/component/FAQ.markdown#how-can-the-parent-of-a-node-be-obtained
+ * @deprecated since 1.1 and will be removed in 2.0. Use PhpParser\NodeVisitor\ParentConnectingVisitor instead.
  */
 final class ParentConnectingVisitor extends NodeVisitorAbstract
 {


### PR DESCRIPTION
This PR switches to the new upstream ParentConnectingVisitor class (you added :P).

NB The tests are failing on PHP 8.0 due to https://github.com/php/php-src/commit/7a3dcc3e339cde2177ba4fe8fc45f78c94dfbb29. I think we can treat that as out of scope of this PR.

NB2 A side effect of this PR is that the old class no longer has test coverage.