### PR TITLE
fix(node-visitor): Ensure that missing statements do not crash in visitor

### DIFF
--- a/src/Visitor/ComplexityCalculatingVisitor.php
+++ b/src/Visitor/ComplexityCalculatingVisitor.php
@@ -50,6 +50,10 @@ final class ComplexityCalculatingVisitor extends NodeVisitorAbstract
 
         assert(is_array($statements));
 
+        if (! $statements) {
+            return null;
+        }
+
         $this->result[] = new Complexity(
             $name,
             $this->cyclomaticComplexity($statements)

--- a/tests/_fixture/ExampleInterface.php
+++ b/tests/_fixture/ExampleInterface.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/complexity.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Complexity\TestFixture;
+
+interface ExampleInterface
+{
+    public function method(): void;
+}


### PR DESCRIPTION
Hello,

I'm not too familiar with assertions in PHP, so perhaps the expectation of this library is that you must have assertions configured in a certain way. If so, feel free to close the issue/PR.

https://github.com/sebastianbergmann/complexity/blob/9fb9f61ae6e4977ef04bbf22d0f8dd7262d6494e/src/Visitor/ComplexityCalculatingVisitor.php#L51

Nevertheless, I'm encountering an error while computing complexity on interfaces.

```
SebastianBergmann\Complexity\ComplexityCalculatingVisitor::cyclomaticComplexity(): Argument #1 ($statements) must be of type array, null given, called in .../vendor/sebastian/complexity/src/Visitor/ComplexityCalculatingVisitor.php on line 61
```

I understand that interfaces have no complexity... so another solution is to filter interfaces and prevent them from ever having their complexity computed. But it would be nice to be able to scan an entire directory without having to perform tedious filtering.

If you'd prefer not to blanket return null, checking the parent node might also work:

```php
        if ((!$node instanceof ClassMethod && !$node instanceof Function_) || $node->getAttribute('parent') instanceof Interface_) { return null; }
```