### PR TITLE
Ensure calculateForSourceFile() throws RuntimeException when the source file does not exist

### DIFF
--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -30,12 +30,15 @@ final class Calculator
      */
     public function calculateForSourceFile(string $sourceFile): ComplexityCollection
     {
-        assert(file_exists($sourceFile));
-        assert(is_readable($sourceFile));
+        if(!file_exists($sourceFile)){
+            throw new RuntimeException('The ' . $sourceFile . ' file does not exist.');
+        }
 
         $source = file_get_contents($sourceFile);
-
-        assert(is_string($source));
+        
+        if(!is_string($source)){
+            throw new RuntimeException('The ' . $sourceFile . ' file is not readable.');
+        }
 
         return $this->calculateForSourceString($source);
     }

--- a/tests/integration/CalculatorTest.php
+++ b/tests/integration/CalculatorTest.php
@@ -76,4 +76,14 @@ final class CalculatorTest extends TestCase
         $this->assertSame('SebastianBergmann\Complexity\TestFixture\ExampleClass::method', $result[0]->name());
         $this->assertSame(14, $result[0]->cyclomaticComplexity());
     }
+
+    public function testThrowsExceptionWhenSourceFileDoesNotExist(): void
+    {
+        $sourceFile = __DIR__ . '/../_fixture/NotExistsFile.php';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageIs('The ' . $sourceFile . ' file does not exist.');
+
+        (new Calculator)->calculateForSourceFile($sourceFile);
+    }
 }


### PR DESCRIPTION
`Calculator::calculateForSourceFile()` documents `RuntimeException` as a possible exception, but previously relied on assertions to check whether the source file existed and was readable.

When assertions are enabled, passing a non-existent file results in an `AssertionError` rather than the documented `RuntimeException`.

When assertions are disabled, the assertions are skipped and `file_get_contents()` can return false, allowing execution to continue without the documented exception.

This change makes file-read failures explicit and ensures that a missing source file results in a `RuntimeException`.

Changes

- Replace the assertion for checking whether the source file exists with an explicit RuntimeException.
- Handle a failed file_get_contents() call with a RuntimeException.
- Add a regression test covering a non-existent source file.